### PR TITLE
HigherOrderExtendTypeProvider

### DIFF
--- a/src/main/kotlin/com/pestphp/pest/customExpectations/ExpectationFileService.kt
+++ b/src/main/kotlin/com/pestphp/pest/customExpectations/ExpectationFileService.kt
@@ -3,6 +3,7 @@ package com.pestphp.pest.customExpectations
 import com.intellij.openapi.application.runReadAction
 import com.intellij.openapi.application.runUndoTransparentWriteAction
 import com.intellij.openapi.application.runWriteAction
+import com.intellij.openapi.components.Service
 import com.intellij.openapi.project.DumbService
 import com.intellij.openapi.project.Project
 import com.intellij.psi.PsiManager
@@ -14,6 +15,7 @@ import com.pestphp.pest.customExpectations.generators.ExpectationGenerator
 import com.pestphp.pest.customExpectations.generators.Method
 import com.pestphp.pest.realPath
 
+@Service
 class ExpectationFileService(val project: Project) {
     private var methods: Map<String, List<Method>> = mutableMapOf()
 

--- a/src/main/kotlin/com/pestphp/pest/types/HigherOrderExtendTypeProvider.kt
+++ b/src/main/kotlin/com/pestphp/pest/types/HigherOrderExtendTypeProvider.kt
@@ -1,0 +1,59 @@
+package com.pestphp.pest.types
+
+import com.intellij.openapi.project.DumbService
+import com.intellij.openapi.project.Project
+import com.intellij.psi.PsiElement
+import com.jetbrains.php.lang.psi.elements.FieldReference
+import com.jetbrains.php.lang.psi.elements.MemberReference
+import com.jetbrains.php.lang.psi.elements.MethodReference
+import com.jetbrains.php.lang.psi.elements.PhpNamedElement
+import com.jetbrains.php.lang.psi.elements.PhpTypedElement
+import com.jetbrains.php.lang.psi.elements.impl.FunctionReferenceImpl
+import com.jetbrains.php.lang.psi.resolve.types.PhpType
+import com.jetbrains.php.lang.psi.resolve.types.PhpTypeProvider4
+import com.pestphp.pest.expectationType
+
+/**
+ * Extend `$this` type with types from `uses`.
+ * Both `uses` from the same file, the pest config file
+ * and `uses` with paths from pest config file.
+ */
+class HigherOrderExtendTypeProvider : PhpTypeProvider4 {
+    override fun getKey(): Char {
+        return '\u0224'
+    }
+
+    override fun getType(psiElement: PsiElement): PhpType? {
+        if (DumbService.isDumb(psiElement.project)) return null
+
+        val reference = psiElement as? MemberReference ?: return null
+
+        if (reference !is FieldReference && reference !is MethodReference) return null
+
+        val expectCall = getExpectCall(reference) ?: return null
+
+        if (expectCall.parameters.isEmpty()) return null
+
+        val firstParameterType = (expectCall.parameters[0] as? PhpTypedElement)?.type ?: return null
+
+        return PhpType().add(firstParameterType).add(expectationType)
+    }
+
+    private fun getExpectCall(reference: MemberReference, depth: Int = 50): FunctionReferenceImpl? {
+        if (depth <= 0) return null
+
+        return when (val classReference = reference.classReference) {
+            is FunctionReferenceImpl -> if (classReference.name == "expect") classReference else null
+            is MemberReference -> getExpectCall(classReference, depth - 1)
+            else -> null
+        }
+    }
+
+    override fun complete(s: String, project: Project): PhpType? {
+        return null
+    }
+
+    override fun getBySignature(s: String, set: Set<String>, i: Int, project: Project): Collection<PhpNamedElement?> {
+        return emptyList()
+    }
+}

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -10,6 +10,8 @@
     <depends optional="true" config-file="pest-coverage.xml">com.intellij.modules.coverage</depends>
 
     <extensions defaultExtensionNs="com.intellij">
+        <projectService serviceImplementation="com.pestphp.pest.PestSettings"/>
+
         <runLineMarkerContributor
                 language="PHP"
                 implementationClass="com.pestphp.pest.PestTestRunLineMarkerProvider"
@@ -25,7 +27,6 @@
         <runConfigurationProducer implementation="com.pestphp.pest.configuration.PestRunConfigurationProducer"/>
         <iconProvider implementation="com.pestphp.pest.PestIconProvider"/>
 
-        <projectService serviceImplementation="com.pestphp.pest.PestSettings"/>
         <testFinder implementation="com.pestphp.pest.goto.PestTestFinder"/>
         <fileBasedIndex implementation="com.pestphp.pest.indexers.PestTestIndex"/>
         <fileBasedIndex implementation="com.pestphp.pest.customExpectations.CustomExpectationIndex"/>
@@ -52,7 +53,6 @@
                 implementationClass="com.pestphp.pest.inspections.SuppressUndefinedPropertyInspection"
         />
         <notificationGroup displayType="BALLOON" id="Outdated Pest" isLogByDefault="true"/>
-        <projectService serviceImplementation="com.pestphp.pest.customExpectations.ExpectationFileService"/>
         <lang.structureViewExtension implementation="com.pestphp.pest.structureView.PestStructureViewExtension"/>
         <gotoSymbolContributor implementation="com.pestphp.pest.goto.PestTestGoToSymbolContributor"/>
         <liveTemplateContext implementation="com.pestphp.pest.templates.PestRootTemplateContextType"/>
@@ -74,6 +74,7 @@
         <typeProvider4 implementation="com.pestphp.pest.types.ThisTypeProvider"/>
         <typeProvider4 implementation="com.pestphp.pest.types.ThisFieldTypeProvider"/>
         <typeProvider4 implementation="com.pestphp.pest.types.ThisExtendTypeProvider"/>
+        <typeProvider4 implementation="com.pestphp.pest.types.HigherOrderExtendTypeProvider"/>
         <libraryRoot id="pestphp" path="/library/Pest" runtime="false"/>
     </extensions>
 

--- a/src/test/resources/com/pestphp/pest/higherOrderExpectations/ExpectMethodCompletionChained.php
+++ b/src/test/resources/com/pestphp/pest/higherOrderExpectations/ExpectMethodCompletionChained.php
@@ -1,9 +1,17 @@
 <?php
 
-class Example {
-    public function getDate(): DateTime
+class Chained
+{
+    public function getTimestamp()
     {
-        return new DateTime();
+    }
+}
+
+class Example
+{
+    public function getDate(): Chained
+    {
+        return new Chained();
     }
 }
 

--- a/src/test/resources/com/pestphp/pest/higherOrderExpectations/ExpectPropertyCompletionChained.php
+++ b/src/test/resources/com/pestphp/pest/higherOrderExpectations/ExpectPropertyCompletionChained.php
@@ -1,11 +1,18 @@
 <?php
 
+class Chained
+{
+    public function getTimestamp()
+    {
+    }
+}
+
 class Example {
-    public DateTime $date;
+    public Chained $date;
 
     public function __construct()
     {
-        $this->date = new DateTime();
+        $this->date = new Chained();
     }
 }
 


### PR DESCRIPTION
I managed to make these tests green. A bit dirty solution, but it works. I've added `Service` annotation and `projectService` EP in the plugin.xml. They didn't want to work without it. You can remove them...