### PR TITLE
Allow regex to match tests with both named and unnamed datasets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@
 ### Changed
 - Removed the "test started at" text on the test console output
 
+### Fixed
+- Fixed regex to match tests that have both named and unnamed datasets
+
 ## [1.8.1]
 ### Fixed
 - Fixed originalFile in iconProvider sometimes being null

--- a/src/main/kotlin/com/pestphp/pest/PestNamingUtil.kt
+++ b/src/main/kotlin/com/pestphp/pest/PestNamingUtil.kt
@@ -107,7 +107,10 @@ fun String.toPestTestRegex(rootPath: String, file: String, pathMapper: PhpPathMa
         .replace("^", "\\^")
         .replace("/", "\\/")
 
-    return """^$fqn::$testName(\swith\s((data\sset\s".*")|(\(.*\)(\s#\d+)?)))?$"""
+    // Match the description of a single data set
+    val dataSet = """(data\sset\s".*"|\(.*\))"""
+
+    return """^$fqn::$testName(\swith\s$dataSet(\s\/\s$dataSet)*(\s#\d+)?)?$"""
 }
 
 val String.withoutFirstFileSeparator: String


### PR DESCRIPTION
Fix the generation of Pest test name regex so that tests that have both named and unnamed datasets can run.

* [ ] Added or updated tests
* [x] Updated CHANGELOG.md

issues: #376