### PR TITLE
dataset Find Usages GoTo handler

### DIFF
--- a/src/main/kotlin/com/pestphp/pest/features/datasets/DatasetReferenceProvider.kt
+++ b/src/main/kotlin/com/pestphp/pest/features/datasets/DatasetReferenceProvider.kt
@@ -1,16 +1,11 @@
 package com.pestphp.pest.features.datasets
 
 import com.intellij.psi.PsiElement
-import com.intellij.psi.PsiManager
 import com.intellij.psi.PsiReference
 import com.intellij.psi.PsiReferenceProvider
-import com.intellij.psi.search.GlobalSearchScope
 import com.intellij.util.ProcessingContext
-import com.intellij.util.indexing.FileBasedIndex
+import com.jetbrains.php.lang.psi.elements.MethodReference
 import com.jetbrains.php.lang.psi.elements.StringLiteralExpression
-import com.jetbrains.php.lang.psi.elements.impl.FunctionReferenceImpl
-import com.pestphp.pest.getRootPhpPsiElements
-import com.pestphp.pest.isPestTestReference
 
 /**
  * Adds goto and reference support to string literals referring datasets
@@ -24,16 +19,9 @@ class DatasetReferenceProvider : PsiReferenceProvider() {
             return PsiReference.EMPTY_ARRAY
         }
 
-        val isPestTest = element
-            // Parameter list (with call parameters)
-            .parent
-            // Method reference (pest test call)
-            .parent
-            // Check if method reference is a pest test
-            .isPestTestReference()
-        if (!isPestTest) {
-            return PsiReference.EMPTY_ARRAY
-        }
+        val methodReference = element.parent?.parent as? MethodReference ?: return PsiReference.EMPTY_ARRAY
+
+        if (!methodReference.isDatasetCall()) return PsiReference.EMPTY_ARRAY
 
         return arrayOf(
             DatasetReference(element)

--- a/src/main/kotlin/com/pestphp/pest/features/datasets/DatasetUtil.kt
+++ b/src/main/kotlin/com/pestphp/pest/features/datasets/DatasetUtil.kt
@@ -4,9 +4,11 @@ import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiFile
 import com.intellij.psi.search.ProjectScope
 import com.intellij.util.indexing.FileBasedIndex
+import com.jetbrains.php.lang.psi.elements.MethodReference
 import com.jetbrains.php.lang.psi.elements.StringLiteralExpression
 import com.jetbrains.php.lang.psi.elements.impl.FunctionReferenceImpl
 import com.pestphp.pest.getRootPhpPsiElements
+import com.pestphp.pest.isPestTestReference
 import com.pestphp.pest.realPath
 
 fun PsiFile.isPestDatasetFile(): Boolean {
@@ -24,7 +26,6 @@ fun PsiFile.isIndexedPestDatasetFile(): Boolean {
 
 fun PsiElement?.isPestDataset(): Boolean {
     return when (this) {
-        null -> false
         is FunctionReferenceImpl -> this.isPestDatasetFunction()
         else -> false
     }
@@ -36,6 +37,12 @@ fun FunctionReferenceImpl.isPestDatasetFunction(): Boolean {
 
 fun FunctionReferenceImpl.getPestDatasetName(): String? {
     return (getParameter(0) as? StringLiteralExpression)?.contents
+}
+
+fun MethodReference.isDatasetCall() : Boolean {
+    if (name != "with") return false
+
+    return isPestTestReference()
 }
 
 fun PsiFile.getDatasets(): List<FunctionReferenceImpl> {

--- a/src/main/kotlin/com/pestphp/pest/goto/PestDatasetUsagesGotoHandler.kt
+++ b/src/main/kotlin/com/pestphp/pest/goto/PestDatasetUsagesGotoHandler.kt
@@ -1,0 +1,55 @@
+package com.pestphp.pest.goto
+
+import com.intellij.codeInsight.navigation.actions.GotoDeclarationHandler
+import com.intellij.openapi.editor.Editor
+import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiFile
+import com.intellij.psi.search.GlobalSearchScope
+import com.intellij.psi.search.PsiSearchHelper
+import com.intellij.psi.util.PsiTreeUtil
+import com.intellij.util.Processor
+import com.jetbrains.php.lang.psi.elements.MethodReference
+import com.jetbrains.php.lang.psi.elements.StringLiteralExpression
+import com.jetbrains.php.lang.psi.elements.impl.FunctionReferenceImpl
+import com.pestphp.pest.features.datasets.isDatasetCall
+import com.pestphp.pest.features.datasets.isPestDatasetFunction
+
+class PestDatasetUsagesGotoHandler: GotoDeclarationHandler {
+    override fun getGotoDeclarationTargets(
+        sourceElement: PsiElement?,
+        offset: Int,
+        editor: Editor?
+    ): Array<PsiElement>? {
+        val literal = sourceElement?.parent as? StringLiteralExpression ?: return null
+
+        val function = literal.parent?.parent as? FunctionReferenceImpl ?: return null
+
+        if (!function.isPestDatasetFunction()) return null
+
+        val searchHelper = PsiSearchHelper.getInstance(literal.project)
+        val result = mutableListOf<PsiElement>()
+        val datasetName = literal.contents
+
+        val processor = Processor { psiFile: PsiFile ->
+            result.addAll(
+                PsiTreeUtil.findChildrenOfType(psiFile, StringLiteralExpression::class.java).filter {
+                    it.contents == datasetName
+                }.mapNotNull {
+                    it.parent?.parent as? MethodReference
+                }.filter {
+                    it.isDatasetCall()
+                }
+            )
+
+            true
+        }
+
+        searchHelper.processAllFilesWithWordInLiterals(
+            datasetName,
+            GlobalSearchScope.allScope(literal.project),
+            processor,
+        )
+
+        return result.toTypedArray()
+    }
+}

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -76,6 +76,7 @@
         <completion.contributor implementationClass="com.pestphp.pest.completion.PestCompletionContributor"
                                 language="PHP"/>
         <gotoDeclarationHandler implementation="com.pestphp.pest.completion.ThisFieldsCompletionProvider"/>
+        <gotoDeclarationHandler implementation="com.pestphp.pest.goto.PestDatasetUsagesGotoHandler"/>
         <lang.inspectionSuppressor
                 language="PHP"
                 implementationClass="com.pestphp.pest.inspections.SuppressExpressionResultUnusedInspection"/>

--- a/src/test/kotlin/com/pestphp/pest/features/datasets/DatasetReferenceTest.kt
+++ b/src/test/kotlin/com/pestphp/pest/features/datasets/DatasetReferenceTest.kt
@@ -13,34 +13,46 @@ class DatasetReferenceTest : PestLightCodeFixture() {
     fun testReferenceToDatasetInSameFile() {
         val file = myFixture.configureByFile("DatasetReference.php")
 
-        val caretElement = file.findElementAt(myFixture.caretOffset)!!
-        val datasetReference = caretElement.parent.references[0] as DatasetReference
-        val resolved = datasetReference.resolve() as? FunctionReferenceImpl
+        val caretElement = file.findElementAt(myFixture.caretOffset) ?: return fail("No element")
+        val datasetReference = caretElement.parent.references.filterIsInstance<DatasetReference>().firstOrNull() ?: return fail("No reference")
+        val resolved = datasetReference.resolve() as? FunctionReferenceImpl ?: return fail("No function")
 
-        assertNotNull(datasetReference)
         assertTrue(resolved.isPestDataset())
-        assertEquals("dojos", resolved!!.getPestDatasetName())
+        assertEquals("dojos", resolved.getPestDatasetName())
     }
 
     fun testReferenceDatasetInOtherFile() {
         myFixture.copyFileToProject("Datasets.php", "tests/Datasets/stances.php")
         val file = myFixture.configureByFile("SharedDatasetReference.php")
 
-        val caretElement = file.findElementAt(myFixture.caretOffset)!!
-        val datasetReference = caretElement.parent.references[0] as DatasetReference
-        val resolved = datasetReference.resolve() as? FunctionReferenceImpl
+        val caretElement = file.findElementAt(myFixture.caretOffset) ?: return fail("No element")
+        val datasetReference = caretElement.parent.references.filterIsInstance<DatasetReference>().firstOrNull() ?: return fail("No reference")
+        val resolved = datasetReference.resolve() as? FunctionReferenceImpl ?: return fail("No function")
 
-        assertNotNull(datasetReference)
         assertTrue(resolved.isPestDataset())
-        assertEquals("stances", resolved!!.getPestDatasetName())
+        assertEquals("stances", resolved.getPestDatasetName())
+    }
+
+    fun testDoubleWith() {
+        myFixture.copyFileToProject("Datasets.php", "tests/Datasets/stances.php")
+        myFixture.configureByFile("DoubleWithDatasetReference.php")
+
+        assertCompletion("stances")
+    }
+
+    fun testNotDataset() {
+        myFixture.copyFileToProject("Datasets.php", "tests/Datasets/stances.php")
+        myFixture.configureByFile("NotDatasetReference.php")
+
+        assertNoCompletion()
     }
 
     fun testCannotGoToDatasetInNonPestTest() {
         myFixture.copyFileToProject("Datasets.php", "tests/Datasets/stances.php")
         val file = myFixture.configureByFile("DatasetOnNonPestTest.php")
 
-        val caretElement = file.findElementAt(myFixture.caretOffset)!!
-        val datasetReference = caretElement.parent.references
+        val caretElement = file.findElementAt(myFixture.caretOffset) ?: return fail("No element")
+        val datasetReference = caretElement.parent.references.filterIsInstance<DatasetReference>()
 
         assertSize(0, datasetReference)
     }

--- a/src/test/kotlin/com/pestphp/pest/features/datasets/DatasetUsagesTest.kt
+++ b/src/test/kotlin/com/pestphp/pest/features/datasets/DatasetUsagesTest.kt
@@ -1,0 +1,28 @@
+package com.pestphp.pest.features.datasets
+
+import com.intellij.testFramework.TestDataPath
+import com.jetbrains.php.lang.psi.elements.MethodReference
+import com.pestphp.pest.PestLightCodeFixture
+import com.pestphp.pest.goto.PestDatasetUsagesGotoHandler
+import junit.framework.TestCase
+
+@TestDataPath("/com/pestphp/pest/goto/datasetUsages")
+class DatasetUsagesTest : PestLightCodeFixture() {
+    override fun getTestDataPath(): String {
+        return "src/test/resources/com/pestphp/pest/goto/datasetUsages"
+    }
+
+    fun testGotoUsages() {
+        myFixture.copyFileToProject("DatasetUsage.php", "tests/usages.php")
+        myFixture.copyFileToProject("DatasetDeclaration.php", "tests/Datasets/declaration.php")
+        val file = myFixture.configureFromTempProjectFile("tests/Datasets/declaration.php")
+
+        val element = file.findElementAt(myFixture.caretOffset) ?: return fail("No element")
+
+        val usages = PestDatasetUsagesGotoHandler().getGotoDeclarationTargets(element, 0, null) ?: return fail("No usages")
+
+        assertEquals(2, usages.size)
+        TestCase.assertTrue(usages.any { it is MethodReference && it.containingFile?.name == "usages.php" })
+        TestCase.assertTrue(usages.any { it is MethodReference && it.containingFile?.name == "declaration.php" })
+    }
+}

--- a/src/test/resources/com/pestphp/pest/features/datasets/DoubleWithDatasetReference.php
+++ b/src/test/resources/com/pestphp/pest/features/datasets/DoubleWithDatasetReference.php
@@ -1,0 +1,8 @@
+<?php
+
+it('can check if in the valley', function (string $dojo) {
+
+})->with([
+    Bar::class,
+    Restaurant::class,
+])->with('<caret>');

--- a/src/test/resources/com/pestphp/pest/features/datasets/NotDatasetReference.php
+++ b/src/test/resources/com/pestphp/pest/features/datasets/NotDatasetReference.php
@@ -1,0 +1,5 @@
+<?php
+
+it('can check if in the valley', function (string $dojo) {
+
+})->notDataset('<caret>');

--- a/src/test/resources/com/pestphp/pest/goto/datasetUsages/DatasetDeclaration.php
+++ b/src/test/resources/com/pestphp/pest/goto/datasetUsages/DatasetDeclaration.php
@@ -1,0 +1,15 @@
+<?php
+
+dataset('<caret>datasetName', [
+    'Seiza',
+    'Musubi Dachi',
+    'Heisoku Dachi',
+    'Heiko Dachi',
+    'Zenkutsu Dachi',
+    'Han Zenkutsu Dachi',
+    'Kokutsu Dachi',
+]);
+
+it('can check if in the valley', function (string $dojo) {
+
+})->with('datasetName');

--- a/src/test/resources/com/pestphp/pest/goto/datasetUsages/DatasetUsage.php
+++ b/src/test/resources/com/pestphp/pest/goto/datasetUsages/DatasetUsage.php
@@ -1,0 +1,5 @@
+<?php
+
+it('can check if in the valley', function (string $dojo) {
+
+})->with([])->with('datasetName');


### PR DESCRIPTION
Find usages works. It looks ugly because string literals aren't "named" elements in PhpStorm, so there is no possibility to add the usual "Find usages" for it. And. renaming will also be a problem)

- [x] Added or updated tests
- [ ] Updated `CHANGELOG.md`

issues: #320
