### PR TITLE
fix(coverage): Fix selected engine not saved

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 # PEST IntelliJ Changelog
 
 ## Unreleased
+### Fixed
+- Fixed "Preferred Coverage Engine" not being saved
 
 ## 1.9.1 - 2023-02-28
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,7 +3,7 @@
 
 pluginGroup = com.pestphp
 pluginName = PEST PHP
-pluginVersion = 1.9.1
+pluginVersion = 1.9.2
 
 # See https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 # for insight into build numbers and IntelliJ Platform versions.

--- a/src/main/kotlin/com/pestphp/pest/configuration/PestRunConfiguration.kt
+++ b/src/main/kotlin/com/pestphp/pest/configuration/PestRunConfiguration.kt
@@ -51,7 +51,7 @@ class PestRunConfiguration(project: Project, factory: ConfigurationFactory) : Ph
         val editor = this.getConfigurationEditor(names)
 
         editor.setRunnerOptionsDocumentation("https://pestphp.com/docs/installation")
-        return PestTestRunConfigurationEditor(editor, project, this)
+        return PestTestRunConfigurationEditor(editor, this)
     }
 
     @Throws(ExecutionException::class)

--- a/src/main/kotlin/com/pestphp/pest/configuration/PestTestRunConfigurationEditor.kt
+++ b/src/main/kotlin/com/pestphp/pest/configuration/PestTestRunConfigurationEditor.kt
@@ -5,7 +5,6 @@ import com.intellij.openapi.options.SettingsEditor
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.ui.ComboBox
 import com.intellij.util.ui.UI
-import com.jetbrains.php.config.interpreters.PhpInterpretersManagerImpl
 import com.jetbrains.php.phpunit.coverage.PhpUnitCoverageEngine.CoverageEngine
 import com.jetbrains.php.testFramework.run.PhpTestRunConfigurationEditor
 import java.awt.BorderLayout
@@ -15,7 +14,6 @@ import javax.swing.JPanel
 
 class PestTestRunConfigurationEditor(
     private val parentEditor: PhpTestRunConfigurationEditor,
-    project: Project,
     settings: PestRunConfiguration
 ) : SettingsEditor<PestRunConfiguration>() {
     private val myMainPanel = JPanel()
@@ -30,19 +28,7 @@ class PestTestRunConfigurationEditor(
         myMainPanel.layout = BorderLayout()
         myMainPanel.add(parentEditor.component, BorderLayout.CENTER)
         myMainPanel.add(coveragePanel, BorderLayout.SOUTH)
-        coverageEngineComboBox.addItemListener { this.validateEngine(project) }
         resetEditorFrom(settings)
-    }
-
-    private fun validateEngine(project: Project) {
-        val item = coverageEngineComboBox.selectedItem as CoverageEngine
-
-        val interpreter = PhpInterpretersManagerImpl
-            .getInstance(project)
-            .findInterpreter(item.name) ?: return
-
-        CoverageEngine.validateCoverageEngine(interpreter, project, item)
-        TODO("Show error message when validation fails.")
     }
 
     override fun createEditor(): JComponent {


### PR DESCRIPTION
The validation logic for the coverage engine made the dialog not able to save.

<!-- Description of what has been changed or added in this pr and why -->

Thanks to @EdieLemoine for troubleshooting the bug.


- [ ] Added or updated tests
- [x] Updated `CHANGELOG.md`

fixes: #398 
